### PR TITLE
Use name or name_prefix consistently

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,9 @@ module "db" {
 | tags | A mapping of tags to assign to all resources | map | `<map>` | no |
 | timeouts | (Optional) Updated Terraform resource management timeouts. Applies to `aws_db_instance` in particular to permit resource management times | map | `<map>` | no |
 | timezone | (Optional) Time zone of the DB instance. timezone is currently only supported by Microsoft SQL Server. The timezone can only be set on creation. See MSSQL User Guide for more information. | string | `""` | no |
+| use\_option\_group\_name\_prefix | Whether to use the parameter group name prefix or not | string | `"true"` | no |
 | use\_parameter\_group\_name\_prefix | Whether to use the parameter group name prefix or not | string | `"true"` | no |
+| use\_subnet\_group\_name\_prefix | Whether to use the parameter group name prefix or not | string | `"true"` | no |
 | username | Username for the master DB user | string | n/a | yes |
 | vpc\_security\_group\_ids | List of VPC security groups to associate | list | `<list>` | no |
 

--- a/main.tf
+++ b/main.tf
@@ -12,10 +12,12 @@ locals {
 module "db_subnet_group" {
   source = "./modules/db_subnet_group"
 
-  create      = "${local.enable_create_db_subnet_group}"
-  identifier  = "${var.identifier}"
-  name_prefix = "${var.identifier}-"
-  subnet_ids  = ["${var.subnet_ids}"]
+  create          = "${local.enable_create_db_subnet_group}"
+  identifier      = "${var.identifier}"
+  name            = "${var.db_subnet_group_name}"
+  name_prefix     = "${var.identifier}-"
+  use_name_prefix = "${var.use_subnet_group_name_prefix}"
+  subnet_ids      = ["${var.subnet_ids}"]
 
   tags = "${var.tags}"
 }
@@ -41,7 +43,9 @@ module "db_option_group" {
 
   create                   = "${local.enable_create_db_option_group}"
   identifier               = "${var.identifier}"
+  name                     = "${var.option_group_name}"
   name_prefix              = "${var.identifier}-"
+  use_name_prefix          = "${var.use_option_group_name_prefix}"
   option_group_description = "${var.option_group_description}"
   engine_name              = "${var.engine}"
   major_engine_version     = "${var.major_engine_version}"

--- a/modules/db_option_group/README.md
+++ b/modules/db_option_group/README.md
@@ -9,10 +9,12 @@
 | engine\_name | Specifies the name of the engine that this option group should be associated with | string | n/a | yes |
 | identifier | The identifier of the resource | string | n/a | yes |
 | major\_engine\_version | Specifies the major version of the engine that this option group should be associated with | string | n/a | yes |
+| name | The name of the DB option group | string | `""` | no |
 | name\_prefix | Creates a unique name beginning with the specified prefix | string | n/a | yes |
 | option\_group\_description | The description of the option group | string | `""` | no |
 | options | A list of Options to apply | list | `<list>` | no |
 | tags | A mapping of tags to assign to the resource | map | `<map>` | no |
+| use\_name\_prefix | Whether to use name_prefix or not | string | `"true"` | no |
 
 ## Outputs
 

--- a/modules/db_option_group/main.tf
+++ b/modules/db_option_group/main.tf
@@ -16,7 +16,6 @@ resource "aws_db_option_group" "this_no_prefix" {
 }
 
 resource "aws_db_option_group" "this" {
-
   count = "${var.create && var.use_name_prefix ? 1 : 0}"
 
   name_prefix              = "${var.name_prefix}"

--- a/modules/db_option_group/main.tf
+++ b/modules/db_option_group/main.tf
@@ -1,5 +1,23 @@
+resource "aws_db_option_group" "this_no_prefix" {
+  count = "${var.create && ! var.use_name_prefix ? 1 : 0}"
+
+  name                     = "${var.name}"
+  option_group_description = "${var.option_group_description == "" ? format("Option group for %s", var.identifier) : var.option_group_description}"
+  engine_name              = "${var.engine_name}"
+  major_engine_version     = "${var.major_engine_version}"
+
+  option = ["${var.options}"]
+
+  tags = "${merge(var.tags, map("Name", format("%s", var.name)))}"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
 resource "aws_db_option_group" "this" {
-  count = "${var.create ? 1 : 0}"
+
+  count = "${var.create && var.use_name_prefix ? 1 : 0}"
 
   name_prefix              = "${var.name_prefix}"
   option_group_description = "${var.option_group_description == "" ? format("Option group for %s", var.identifier) : var.option_group_description}"

--- a/modules/db_option_group/variables.tf
+++ b/modules/db_option_group/variables.tf
@@ -3,6 +3,11 @@ variable "create" {
   default     = true
 }
 
+variable "name" {
+  default     = ""
+  description = "The name of the DB option group"
+}
+
 variable "name_prefix" {
   description = "Creates a unique name beginning with the specified prefix"
 }
@@ -34,4 +39,9 @@ variable "tags" {
   type        = "map"
   description = "A mapping of tags to assign to the resource"
   default     = {}
+}
+
+variable "use_name_prefix" {
+  description = "Whether to use name_prefix or not"
+  default     = true
 }

--- a/modules/db_subnet_group/README.md
+++ b/modules/db_subnet_group/README.md
@@ -7,6 +7,7 @@
 |------|-------------|:----:|:-----:|:-----:|
 | create | Whether to create this resource or not? | string | `"true"` | no |
 | identifier | The identifier of the resource | string | n/a | yes |
+| name | The name of the DB subnet group | string | `""` | no |
 | name\_prefix | Creates a unique name beginning with the specified prefix | string | n/a | yes |
 | subnet\_ids | A list of VPC subnet IDs | list | `<list>` | no |
 | tags | A mapping of tags to assign to the resource | map | `<map>` | no |
@@ -17,5 +18,6 @@
 |------|-------------|
 | this\_db\_subnet\_group\_arn | The ARN of the db subnet group |
 | this\_db\_subnet\_group\_id | The db subnet group name |
+| use\_name\_prefix | Whether to use name_prefix or not | string | `"true"` | no |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/db_subnet_group/main.tf
+++ b/modules/db_subnet_group/main.tf
@@ -1,9 +1,31 @@
+locals {
+  description = "Database subnet group for ${var.identifier}"
+}
+
+resource "aws_db_subnet_group" "this_no_prefix" {
+  count = "${var.create && ! var.use_name_prefix ? 1 : 0}"
+
+  name        = "${var.name}"
+  description = "${local.description}"
+  subnet_ids  = ["${var.subnet_ids}"]
+
+  tags = "${merge(var.tags, map("Name", format("%s", var.name)))}"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
 resource "aws_db_subnet_group" "this" {
-  count = "${var.create ? 1 : 0}"
+  count = "${var.create && var.use_name_prefix ? 1 : 0}"
 
   name_prefix = "${var.name_prefix}"
-  description = "Database subnet group for ${var.identifier}"
+  description = "${local.description}"
   subnet_ids  = ["${var.subnet_ids}"]
 
   tags = "${merge(var.tags, map("Name", format("%s", var.identifier)))}"
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }

--- a/modules/db_subnet_group/variables.tf
+++ b/modules/db_subnet_group/variables.tf
@@ -3,6 +3,11 @@ variable "create" {
   default     = true
 }
 
+variable "name" {
+  default     = ""
+  description = "The name of the DB subnet group"
+}
+
 variable "name_prefix" {
   description = "Creates a unique name beginning with the specified prefix"
 }
@@ -21,4 +26,9 @@ variable "tags" {
   type        = "map"
   description = "A mapping of tags to assign to the resource"
   default     = {}
+}
+
+variable "use_name_prefix" {
+  description = "Whether to use name_prefix or not"
+  default     = true
 }

--- a/variables.tf
+++ b/variables.tf
@@ -273,3 +273,13 @@ variable "use_parameter_group_name_prefix" {
   description = "Whether to use the parameter group name prefix or not"
   default     = true
 }
+
+variable "use_option_group_name_prefix" {
+  description = "Whether to use the parameter group name prefix or not"
+  default     = true
+}
+
+variable "use_subnet_group_name_prefix" {
+  description = "Whether to use the parameter group name prefix or not"
+  default     = true
+}


### PR DESCRIPTION
## Use `name` or `name_prefix` consistently

This PR ensures that the user can consistently choose to either use `name` or `name_prefix` for all sub-module resources:

* Option group (via this PR)
* Subnet group (via this PR)
* Parameter group (already implemented)

It should be a non-breaking change, as the default behaviour remains (using `name_prefix`).